### PR TITLE
Corrected generated weii script with new poetry.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8,<4"
 
+[project.scripts]
+weii = "weii.cli:cli"
+
 [tool.poetry.dependencies]
 evdev = "^1.6.1"
 
@@ -18,6 +21,3 @@ weii = "weii.cli:cli"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[project.scripts]
-weii = "weii:cli"


### PR DESCRIPTION
This ensure the generated script call an existing method, to avoid this error:

   Traceback (most recent call last):
   31s   File "/usr/bin/weii", line 8, in <module>
   31s     sys.exit(cli())
   31s              ~~~^^